### PR TITLE
simplify Caffe2Tracer

### DIFF
--- a/.github/workflows/check-template.yml
+++ b/.github/workflows/check-template.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check-template:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'facebookresearch' }}
     steps:
       - uses: actions/github-script@v2
         with:

--- a/.github/workflows/needs-reply.yml
+++ b/.github/workflows/needs-reply.yml
@@ -18,6 +18,7 @@ jobs:
 
   lock-issues-after-closed:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'facebookresearch' }}
     steps:
       - name: Lock closed issues that have no activity for a while
         uses: dessant/lock-threads@v2

--- a/.github/workflows/remove-needs-reply.yml
+++ b/.github/workflows/remove-needs-reply.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   remove-needs-more-info-label:
     runs-on: ubuntu-latest
+    # issue_comment events include PR comment
+    if: ${{ !github.event.issue.pull_request }}
     steps:
       - name: Remove needs-more-info label
         uses: octokit/request-action@v2.x

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ inference_test_output
 *.png
 *.json
 *.diff
+*.jpg
+!/projects/DensePose/doc/images/*.jpg
 
 # compilation and distribution
 __pycache__
@@ -14,7 +16,7 @@ _ext
 *.pyc
 *.pyd
 *.so
-detectron2.egg-info/
+*.egg-info/
 build/
 dist/
 wheels/
@@ -23,6 +25,8 @@ wheels/
 *.pth
 *.pkl
 *.npy
+*.ts
+model_ts*.txt
 
 # ipython/jupyter notebooks
 *.ipynb
@@ -45,3 +49,4 @@ _darcs
 !/datasets/*.*
 /projects/*/datasets
 /models
+/snippet

--- a/detectron2/export/c10.py
+++ b/detectron2/export/c10.py
@@ -145,6 +145,10 @@ class InstancesList(object):
 
 
 class Caffe2Compatible(object):
+    """
+    A model can inherit this class to indicate that it can be traced and deployed with caffe2.
+    """
+
     def _get_tensor_mode(self):
         return self._tensor_mode
 

--- a/tests/test_export_caffe2.py
+++ b/tests/test_export_caffe2.py
@@ -27,13 +27,19 @@ class TestCaffe2Export(unittest.TestCase):
         model = model_zoo.get(config_path, trained=True, device=device)
 
         inputs = [{"image": get_sample_coco_image()}]
-        c2_model = Caffe2Tracer(cfg, model, copy.deepcopy(inputs)).export_caffe2()
+        tracer = Caffe2Tracer(cfg, model, copy.deepcopy(inputs))
+
+        c2_model = tracer.export_caffe2()
 
         with tempfile.TemporaryDirectory(prefix="detectron2_unittest") as d:
             c2_model.save_protobuf(d)
             c2_model.save_graph(os.path.join(d, "test.svg"), inputs=copy.deepcopy(inputs))
+
             c2_model = Caffe2Model.load_protobuf(d)
-        c2_model(inputs)[0]["instances"]
+            c2_model(inputs)[0]["instances"]
+
+            ts_model = tracer.export_torchscript()
+            ts_model.save(os.path.join(d, "model.ts"))
 
     def testMaskRCNN(self):
         self._test_model("COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml")


### PR DESCRIPTION
Summary: move the logic of _get_traceable to __init__. Should be a no-op.

Reviewed By: alexander-kirillov

Differential Revision: D25751630

fbshipit-source-id: 6985cce9b4647b5a3b6476def1400630b2a88519

Thanks for your contribution!

If you're sending a large PR (e.g., >50 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

